### PR TITLE
Fix build compatibility with KWin/Plasma 6.6 API changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
     Gui
     Core
+    CorePrivate
+    GuiPrivate
     DBus
     UiTools
     Widgets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 English | [中文](README_zh.md)
 
-## This branch only supports Plasma 6.3. For users of older versions, please move to the [main branch](https://github.com/walterfang12/LightlyShaders-Plasma6/)
+##This branch only supports Plasma 6.3. For users of older versions, please move to the [main branch](https://github.com/walterfang12/LightlyShaders-Plasma6/)
 
 # LightlyShaders v3.0
 

--- a/src/blur/blur.cpp
+++ b/src/blur/blur.cpp
@@ -241,7 +241,7 @@ void BlurEffect::updateBlurRegion(EffectWindow *w)
     SurfaceInterface *surf = w->surface();
 
     if (surf && surf->blur()) {
-        content = surf->blur()->region();
+        content = static_cast<QRegion>(surf->blur()->region());
     }
 
     if (auto internal = w->internalWindow()) {
@@ -306,7 +306,7 @@ void BlurEffect::slotWindowDeleted(EffectWindow *w)
     m_helper->blurWindowDeleted(w);
 }
 
-void BlurEffect::slotScreenRemoved(KWin::Output *screen)
+void BlurEffect::slotScreenRemoved(KWin::LogicalOutput *screen)
 {
     for (auto &[window, data] : m_windows) {
         if (auto it = data.render.find(screen); it != data.render.end()) {
@@ -424,27 +424,27 @@ QRegion BlurEffect::blurRegion(EffectWindow *w) const
 
 void BlurEffect::prePaintScreen(ScreenPrePaintData &data, std::chrono::milliseconds presentTime)
 {
-    m_paintedArea = QRegion();
-    m_currentBlur = QRegion();
+    m_paintedArea = Region();
+    m_currentBlur = Region();
     m_currentScreen = effects->waylandDisplay() ? data.screen : nullptr;
 
     effects->prePaintScreen(data, presentTime);
 }
 
-void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime)
+void BlurEffect::prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime)
 {
     // this effect relies on prePaintWindow being called in the bottom to top order
 
-    effects->prePaintWindow(w, data, presentTime);
+    effects->prePaintWindow(view, w, data, presentTime);
 
-    const QRegion oldOpaque = data.opaque;
-    if (data.opaque.intersects(m_currentBlur)) {
+    const Region oldOpaque = data.deviceOpaque;
+    if (data.deviceOpaque.intersects(m_currentBlur)) {
         // to blur an area partially we have to shrink the opaque area of a window
-        QRegion newOpaque;
-        for (const QRect &rect : data.opaque) {
+        Region newOpaque;
+        for (const Rect &rect : data.deviceOpaque.rects()) {
             newOpaque += rect.adjusted(m_expandSize, m_expandSize, -m_expandSize, -m_expandSize);
         }
-        data.opaque = newOpaque;
+        data.deviceOpaque = newOpaque;
 
         // we don't have to blur a region we don't see
         m_currentBlur -= newOpaque;
@@ -452,28 +452,28 @@ void BlurEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::
 
     // if we have to paint a non-opaque part of this window that intersects with the
     // currently blurred region we have to redraw the whole region
-    if ((data.paint - oldOpaque).intersects(m_currentBlur)) {
-        data.paint += m_currentBlur;
+    if ((data.devicePaint - oldOpaque).intersects(m_currentBlur)) {
+        data.devicePaint += m_currentBlur;
     }
 
     // in case this window has regions to be blurred
-    const QRegion blurArea = blurRegion(w).boundingRect().translated(w->pos().toPoint());
+    const Region blurArea = Rect(blurRegion(w).boundingRect().translated(w->pos().toPoint()));
 
     // if this window or a window underneath the blurred area is painted again we have to
     // blur everything
-    if (m_paintedArea.intersects(blurArea) || data.paint.intersects(blurArea)) {
-        data.paint += blurArea;
+    if (m_paintedArea.intersects(blurArea) || data.devicePaint.intersects(blurArea)) {
+        data.devicePaint += blurArea;
         // we have to check again whether we do not damage a blurred area
         // of a window
         if (blurArea.intersects(m_currentBlur)) {
-            data.paint += m_currentBlur;
+            data.devicePaint += m_currentBlur;
         }
     }
 
     m_currentBlur += blurArea;
 
-    m_paintedArea -= data.opaque;
-    m_paintedArea += data.paint;
+    m_paintedArea -= data.deviceOpaque;
+    m_paintedArea += data.devicePaint;
 }
 
 bool BlurEffect::shouldBlur(const EffectWindow *w, int mask, const WindowPaintData &data) const
@@ -496,7 +496,7 @@ bool BlurEffect::shouldBlur(const EffectWindow *w, int mask, const WindowPaintDa
     return true;
 }
 
-void BlurEffect::drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data)
+void BlurEffect::drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const Region &region, WindowPaintData &data)
 {
     blur(renderTarget, viewport, w, mask, region, data);
 
@@ -540,7 +540,7 @@ GLTexture *BlurEffect::ensureNoiseTexture()
     return m_noisePass.noiseTexture.get();
 }
 
-void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data)
+void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const Region &region, WindowPaintData &data)
 {
     auto it = m_windows.find(w);
     if (it == m_windows.end()) {
@@ -578,7 +578,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     }
 
     // Get the effective shape that will be actually blurred. It's possible that all of it will be clipped.
-    const QRegion effectiveShape = blurShape & region;
+    const QRegion effectiveShape = blurShape & static_cast<QRegion>(region);
     if (effectiveShape.isEmpty()) {
         return;
     }
@@ -618,7 +618,7 @@ void BlurEffect::blur(const RenderTarget &renderTarget, const RenderViewport &vi
     }
 
     // Fetch the pixels behind the shape that is going to be blurred.
-    const QRegion dirtyRegion = region & backgroundRect;
+    const QRegion dirtyRegion = static_cast<QRegion>(region) & backgroundRect;
     for (const QRect &dirtyRect : dirtyRegion) {
         renderInfo.framebuffers[0]->blitFromRenderTarget(renderTarget, viewport, dirtyRect, dirtyRect.translated(-backgroundRect.topLeft()));
     }

--- a/src/blur/blur.h
+++ b/src/blur/blur.h
@@ -38,7 +38,7 @@ struct BlurEffectData
     std::optional<QRegion> frame;
 
     /// The render data per screen. Screens can have different color spaces.
-    std::unordered_map<Output *, BlurRenderData> render;
+    std::unordered_map<LogicalOutput *, BlurRenderData> render;
 };
 
 class BlurEffect : public KWin::Effect
@@ -54,8 +54,8 @@ public:
 
     void reconfigure(ReconfigureFlags flags) override;
     void prePaintScreen(ScreenPrePaintData &data, std::chrono::milliseconds presentTime) override;
-    void prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime) override;
-    void drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data) override;
+    void prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime) override;
+    void drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const Region &region, WindowPaintData &data) override;
 
     bool provides(Feature feature) override;
     bool isActive() const override;
@@ -72,7 +72,7 @@ public:
 public Q_SLOTS:
     void slotWindowAdded(KWin::EffectWindow *w);
     void slotWindowDeleted(KWin::EffectWindow *w);
-    void slotScreenRemoved(KWin::Output *screen);
+    void slotScreenRemoved(KWin::LogicalOutput *screen);
     void slotPropertyNotify(KWin::EffectWindow *w, long atom);
     void setupDecorationConnections(EffectWindow *w);
 
@@ -84,7 +84,7 @@ private:
     bool shouldBlur(const EffectWindow *w, int mask, const WindowPaintData &data) const;
     void updateBlurRegion(EffectWindow *w);
 
-    void blur(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data);
+    void blur(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const Region &region, WindowPaintData &data);
 
     GLTexture *ensureNoiseTexture();
 
@@ -121,9 +121,9 @@ private:
 
     bool m_valid = false;
     long net_wm_blur_region = 0;
-    QRegion m_paintedArea; // keeps track of all painted areas (from bottom to top)
-    QRegion m_currentBlur; // keeps track of the currently blured area of the windows(from bottom to top)
-    Output *m_currentScreen = nullptr;
+    Region m_paintedArea; // keeps track of all painted areas (from bottom to top)
+    Region m_currentBlur; // keeps track of the currently blured area of the windows(from bottom to top)
+    LogicalOutput *m_currentScreen = nullptr;
 
     size_t m_iterationCount; // number of times the texture will be downsized to half size
     int m_offset;

--- a/src/lightlyshaders/CMakeLists.txt
+++ b/src/lightlyshaders/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(${LIGHTLYSHADERS}
     Qt6::Core
     Qt6::CorePrivate
     Qt6::Gui
+    Qt6::GuiPrivate
     Qt6::DBus
 
     KWin::kwin

--- a/src/lightlyshaders/lightlyshaders.cpp
+++ b/src/lightlyshaders/lightlyshaders.cpp
@@ -138,7 +138,7 @@ LightlyShadersEffect::windowMaximizedStateChanged(EffectWindow *w, bool horizont
 }
 
 void
-LightlyShadersEffect::setRoundness(const int r, Output *s)
+LightlyShadersEffect::setRoundness(const int r, LogicalOutput *s)
 {
     m_size = r;
     m_screens[s].sizeScaled = float(r)*m_screens[s].scale;
@@ -178,7 +178,7 @@ LightlyShadersEffect::reconfigure(ReconfigureFlags flags)
     }
 
     const auto screens = effects->screens();
-    for(Output *s : screens)
+    for(LogicalOutput *s : screens)
     {
         if (effects->waylandDisplay() == nullptr) {
             s = nullptr;
@@ -194,7 +194,7 @@ LightlyShadersEffect::reconfigure(ReconfigureFlags flags)
 }
 
 void
-LightlyShadersEffect::paintScreen(const RenderTarget &renderTarget, const RenderViewport &viewport, int mask, const QRegion &region, Output *s)
+LightlyShadersEffect::paintScreen(const RenderTarget &renderTarget, const RenderViewport &viewport, int mask, const Region &region, LogicalOutput *s)
 {
     bool set_roundness = false;
 
@@ -219,15 +219,15 @@ LightlyShadersEffect::paintScreen(const RenderTarget &renderTarget, const Render
 }
 
 void
-LightlyShadersEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds time)
+LightlyShadersEffect::prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds time)
 {
     if (!isValidWindow(w) )
     {
-        effects->prePaintWindow(w, data, time);
+        effects->prePaintWindow(view, w, data, time);
         return;
     }
 
-    Output *s = w->screen();
+    LogicalOutput *s = w->screen();
     if (effects->waylandDisplay() == nullptr) {
         s = nullptr;
     }
@@ -253,10 +253,10 @@ LightlyShadersEffect::prePaintWindow(EffectWindow *w, WindowPrePaintData &data, 
                 break;
         }
 
-        data.opaque -= reg;
+        data.deviceOpaque -= Region(reg);
     }
 
-    effects->prePaintWindow(w, data, time);
+    effects->prePaintWindow(view, w, data, time);
 }
 
 bool
@@ -273,9 +273,9 @@ LightlyShadersEffect::isValidWindow(EffectWindow *w)
 }
 
 void
-LightlyShadersEffect::drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const QRegion &region, WindowPaintData &data)
-{    
-    QRectF screen = viewport.renderRect().toRect();
+LightlyShadersEffect::drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const Region &region, WindowPaintData &data)
+{
+    QRectF screen = QRectF(static_cast<QRect>(viewport.renderRect().toRect()));
 
     if (!isValidWindow(w) || (!screen.intersects(w->frameGeometry()) && !(mask & PAINT_WINDOW_TRANSFORMED)) )
     {
@@ -283,7 +283,7 @@ LightlyShadersEffect::drawWindow(const RenderTarget &renderTarget, const RenderV
         return;
     }
 
-    Output *s = w->screen();
+    LogicalOutput *s = w->screen();
     if (effects->waylandDisplay() == nullptr) {
         s = nullptr;
     }

--- a/src/lightlyshaders/lightlyshaders.h
+++ b/src/lightlyshaders/lightlyshaders.h
@@ -39,12 +39,12 @@ public:
     static bool supported();
     static bool enabledByDefault();
 
-    void setRoundness(const int r, Output *s);
+    void setRoundness(const int r, LogicalOutput *s);
 
     void reconfigure(ReconfigureFlags flags) override;
-    void paintScreen(const RenderTarget &renderTarget, const RenderViewport &viewport, int mask, const QRegion &region, Output *s) override;
-    void prePaintWindow(EffectWindow* w, WindowPrePaintData& data, std::chrono::milliseconds time) override;
-    void drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow* w, int mask, const QRegion& region, WindowPaintData& data) override;
+    void paintScreen(const RenderTarget &renderTarget, const RenderViewport &viewport, int mask, const Region &region, LogicalOutput *s) override;
+    void prePaintWindow(RenderView *view, EffectWindow* w, WindowPrePaintData& data, std::chrono::milliseconds time) override;
+    void drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow* w, int mask, const Region& region, WindowPaintData& data) override;
     virtual int requestedEffectChainPosition() const override { return 99; }
 
 protected Q_SLOTS:
@@ -82,7 +82,7 @@ private:
     std::unique_ptr<GLShader> m_shader;
     QSize m_corner;
 
-    std::unordered_map<Output *, LSScreenStruct> m_screens;
+    std::unordered_map<LogicalOutput *, LSScreenStruct> m_screens;
     QMap<EffectWindow *, LSWindowStruct> m_windows;
 };
 


### PR DESCRIPTION
## Summary

Plasma 6.6 introduced breaking changes to the KWin effects API. This PR updates the plugin to compile and work correctly against the new API.

## Changes

- **`LogicalOutput` rename**: Replace all `Output *` with `LogicalOutput *` in effect signatures, maps, and local
variables across `lightlyshaders.h/.cpp` and `blur.h/.cpp`
- **`KWin::Region` type**: Replace `const QRegion &` with `const KWin::Region &` in `paintScreen`, `drawWindow`,
`prePaintWindow`, and `blur()` function signatures; add explicit casts where `QRegion` interop is still needed
- **`prePaintWindow` signature**: Add new leading `RenderView *view` parameter and forward it to
`effects->prePaintWindow()`
- **`WindowPrePaintData` fields**: Replace deprecated `data.opaque` / `data.paint` with `data.deviceOpaque` /
`data.devicePaint`; update loop variable from `const QRect &` to `const Rect &` with `.rects()` iterator
- **CMakeLists**: Add `CorePrivate` and `GuiPrivate` to `find_package(Qt6 ...)` so that `Qt6::CorePrivate` /
`Qt6::GuiPrivate` link targets are resolved

