### PR TITLE
Title: Fix build and crash on Plasma 6.7 (KWin 6.7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Build directories
+/qt6build/
+/build/
+build/
+
+# Editor / IDE
+*.user
+*.kate-swp
+.vscode/
+.idea/
+
+# Compiled objects
+*.o
+*.so

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 English | [中文](README_zh.md)
 
-## This branch builds and runs on Plasma 6.7 (KWin 6.7).
-
 # LightlyShaders v3.0
 
- This effect works correctly with stock Plasma effects. Supports KDE Plasma 6 (tested up to 6.7).
+ This effect works correctly with stock Plasma effects. Supports KDE Plasma Version >= 6.7
 
  ![default](screenshot.png)
 
 
 # Dependencies:
  
-Plasma Version >= 6.0.
+Plasma Version >= 6.7.
  
 You will need qt6, kf6 and kwin development packages.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 English | [中文](README_zh.md)
 
-##This branch only supports Plasma 6.3. For users of older versions, please move to the [main branch](https://github.com/walterfang12/LightlyShaders-Plasma6/)
+## This branch builds and runs on Plasma 6.7 (KWin 6.7).
 
 # LightlyShaders v3.0
 
- This effect works correctly with stock Plasma effects.Supports KDE Plasma 6.
+ This effect works correctly with stock Plasma effects. Supports KDE Plasma 6 (tested up to 6.7).
 
  ![default](screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will need qt6, kf6 and kwin development packages.
 ```
 git clone https://github.com/walterfang12/LightlyShaders-Plasma6
 
-cd LightlyShaders;
+cd LightlyShaders-Plasma6;
 
 mkdir qt6build; cd qt6build; cmake ../ -DCMAKE_INSTALL_PREFIX=/usr && make && sudo make install
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,10 +1,10 @@
 [English](README.md) | 中文
 
-## 此分支仅支持Plasma 6.3，旧版本用户请移步[主分支](https://github.com/walterfang12/LightlyShaders-Plasma6/)
+## 此分支可在 Plasma 6.7（KWin 6.7）上编译并运行。
 
 # LightlyShaders v3.0
 
- 此效果与已有的 Plasma 特效一起正常工作。支持 KDE Plasma 6。
+ 此效果与已有的 Plasma 特效一起正常工作。支持 KDE Plasma 6（已在 6.7 上测试）。
 
  ![default](screenshot.png)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,16 +1,14 @@
 [English](README.md) | 中文
 
-## 此分支可在 Plasma 6.7（KWin 6.7）上编译并运行。
-
 # LightlyShaders v3.0
 
- 此效果与已有的 Plasma 特效一起正常工作。支持 KDE Plasma 6（已在 6.7 上测试）。
+ 此效果与已有的 Plasma 特效一起正常工作。支持 KDE Plasma 版本 >= 6.7。
 
  ![default](screenshot.png)
 
 # 依赖关系：
 
- Plasema版本>=6.0。 
+ Plasma版本>=6.7。 
 
  您将需要qt6、kf6和kwin开发包。 
 
@@ -21,7 +19,7 @@
 # 手动安装 
 
 ```bash
-git clone https://github.com/walterfang12/LightlyShaders-Plasma6 && cd LightlyShaders
+git clone https://github.com/walterfang12/LightlyShaders-Plasma6 && cd LightlyShaders-Plasma6
 mkdir qt6build && cd qt6build
 cmake ../ -DCMAKE_INSTALL_PREFIX=/usr && make && sudo make install
 ```

--- a/src/blur/CMakeLists.txt
+++ b/src/blur/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(lightlyshaders_blur PRIVATE
 
     KDecoration3::KDecoration
 
+    XCB::XCB
+
     lshelper
 )
 

--- a/src/blur/blur.cpp
+++ b/src/blur/blur.cpp
@@ -410,8 +410,13 @@ QRegion BlurEffect::blurRegion(EffectWindow *w) const
                 if (frame.has_value()) {
                     region = frame.value();
                 }
-                QRectF rectF = w->decoration()->rect();
-                QRect rect = rectF.toRect(); // 将 QRectF 转换为 QRect
+                // Client-side-decorated / Wayland windows (e.g. plasmashell
+                // panels) have no server-side decoration, so w->decoration()
+                // is null. Fall back to the whole window rect in that case
+                // instead of dereferencing a null pointer.
+                const QRect rect = w->decoration()
+                    ? QRectF(w->decoration()->rect()).toRect()
+                    : QRectF(w->rect()).toRect();
                 region += content->translated(w->contentsRect().topLeft().toPoint()) & rect;
             }
         } else if (frame.has_value()) {

--- a/src/blur/blur.cpp
+++ b/src/blur/blur.cpp
@@ -14,10 +14,12 @@
 #include "core/renderviewport.h"
 #include "effect/effecthandler.h"
 #include "opengl/glplatform.h"
-#include "wayland/blur.h"
 #include "wayland/display.h"
 #include "wayland/surface.h"
 #include "utils/xcbutils.h"
+#if KWIN_BUILD_X11
+#include "x11window.h"
+#endif
 
 #include <QGuiApplication>
 #include <QMatrix4x4>
@@ -41,13 +43,18 @@ static void ensureResources()
     Q_INIT_RESOURCE(blur);
 }
 
+// Scales a rectangle by a scalar factor. Newer KWin dropped the scaledRect
+// helper that used to live in the blur effect, so keep a local copy.
+static QRectF scaledRect(const QRectF &rect, qreal scale)
+{
+    return QRectF(rect.x() * scale, rect.y() * scale, rect.width() * scale, rect.height() * scale);
+}
+
 namespace KWin
 {
 
 static const QByteArray s_blurAtomName = QByteArrayLiteral("_KDE_NET_WM_BLUR_BEHIND_REGION");
 
-BlurManagerInterface *BlurEffect::s_blurManager = nullptr;
-QTimer *BlurEffect::s_blurManagerRemoveTimer = nullptr;
 
 BlurEffect::BlurEffect()
 {
@@ -99,20 +106,8 @@ BlurEffect::BlurEffect()
         net_wm_blur_region = effects->announceSupportProperty(s_blurAtomName, this);
     }
 
-    if (effects->waylandDisplay()) {
-        if (!s_blurManagerRemoveTimer) {
-            s_blurManagerRemoveTimer = new QTimer(QCoreApplication::instance());
-            s_blurManagerRemoveTimer->setSingleShot(true);
-            s_blurManagerRemoveTimer->callOnTimeout([]() {
-                s_blurManager->remove();
-                s_blurManager = nullptr;
-            });
-        }
-        s_blurManagerRemoveTimer->stop();
-        if (!s_blurManager) {
-            s_blurManager = new BlurManagerInterface(effects->waylandDisplay(), s_blurManagerRemoveTimer);
-        }
-    }
+    // Newer KWin registers the org_kde_kwin_blur_manager Wayland global itself,
+    // so the effect no longer needs to (and can't) create BlurManagerInterface.
 
     connect(effects, &EffectsHandler::windowAdded, this, &BlurEffect::slotWindowAdded);
     connect(effects, &EffectsHandler::windowDeleted, this, &BlurEffect::slotWindowDeleted);
@@ -133,10 +128,6 @@ BlurEffect::BlurEffect()
 
 BlurEffect::~BlurEffect()
 {
-    // When compositing is restarted, avoid removing the manager immediately.
-    if (s_blurManager) {
-        s_blurManagerRemoveTimer->start(1000);
-    }
 }
 
 void BlurEffect::initBlurStrengthValues()
@@ -220,28 +211,40 @@ void BlurEffect::updateBlurRegion(EffectWindow *w)
     std::optional<QRegion> content;
     std::optional<QRegion> frame;
 
+#if KWIN_BUILD_X11
     if (net_wm_blur_region != XCB_ATOM_NONE) {
-        const QByteArray value = w->readProperty(net_wm_blur_region, XCB_ATOM_CARDINAL, 32);
-        QRegion region;
-        if (value.size() > 0 && !(value.size() % (4 * sizeof(uint32_t)))) {
-            const uint32_t *cardinals = reinterpret_cast<const uint32_t *>(value.constData());
-            for (unsigned int i = 0; i < value.size() / sizeof(uint32_t);) {
-                int x = cardinals[i++];
-                int y = cardinals[i++];
-                int w = cardinals[i++];
-                int h = cardinals[i++];
-                region += Xcb::fromXNative(QRect(x, y, w, h)).toRect();
+        // Newer KWin no longer exposes EffectWindow::readProperty(); read the
+        // X11 blur-behind property directly through Xcb::Property instead.
+        if (const auto x11Window = qobject_cast<X11Window *>(w->window())) {
+            Xcb::Property wmBlurRegionProperty(false, x11Window->window(),
+                                               net_wm_blur_region, XCB_ATOM_CARDINAL, 0, 32768);
+            if (const auto cardinals = wmBlurRegionProperty.array<uint32_t>()) {
+                if (cardinals->size() == 0 || cardinals->size() == 1) {
+                    // An empty region means the whole window should be blurred.
+                    content = QRegion();
+                } else if (cardinals->size() % 4 == 0) {
+                    QRegion region;
+                    for (uint i = 0; i < cardinals->size();) {
+                        const int x = (*cardinals)[i++];
+                        const int y = (*cardinals)[i++];
+                        const int rw = (*cardinals)[i++];
+                        const int rh = (*cardinals)[i++];
+                        region += QRectF(Xcb::fromXNative(Rect(x, y, rw, rh))).toRect();
+                    }
+                    content = region;
+                }
             }
         }
-        if (!value.isNull()) {
-            content = region;
-        }
     }
+#endif
 
     SurfaceInterface *surf = w->surface();
 
-    if (surf && surf->blur()) {
-        content = static_cast<QRegion>(surf->blur()->region());
+    if (surf) {
+        const RegionF blurRegion = surf->blurRegion();
+        if (!blurRegion.isEmpty()) {
+            content = static_cast<QRegion>(blurRegion.rounded());
+        }
     }
 
     if (auto internal = w->internalWindow()) {
@@ -402,7 +405,7 @@ QRegion BlurEffect::blurRegion(EffectWindow *w) const
             if (content->isEmpty()) {
                 // An empty region means that the blur effect should be enabled
                 // for the whole window.
-                region = w->rect().toRect();
+                region = QRectF(w->rect()).toRect();
             } else {
                 if (frame.has_value()) {
                     region = frame.value();
@@ -422,58 +425,11 @@ QRegion BlurEffect::blurRegion(EffectWindow *w) const
     return region;
 }
 
-void BlurEffect::prePaintScreen(ScreenPrePaintData &data, std::chrono::milliseconds presentTime)
+void BlurEffect::prePaintScreen(ScreenPrePaintData &data)
 {
-    m_paintedArea = Region();
-    m_currentBlur = Region();
     m_currentScreen = effects->waylandDisplay() ? data.screen : nullptr;
 
-    effects->prePaintScreen(data, presentTime);
-}
-
-void BlurEffect::prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime)
-{
-    // this effect relies on prePaintWindow being called in the bottom to top order
-
-    effects->prePaintWindow(view, w, data, presentTime);
-
-    const Region oldOpaque = data.deviceOpaque;
-    if (data.deviceOpaque.intersects(m_currentBlur)) {
-        // to blur an area partially we have to shrink the opaque area of a window
-        Region newOpaque;
-        for (const Rect &rect : data.deviceOpaque.rects()) {
-            newOpaque += rect.adjusted(m_expandSize, m_expandSize, -m_expandSize, -m_expandSize);
-        }
-        data.deviceOpaque = newOpaque;
-
-        // we don't have to blur a region we don't see
-        m_currentBlur -= newOpaque;
-    }
-
-    // if we have to paint a non-opaque part of this window that intersects with the
-    // currently blurred region we have to redraw the whole region
-    if ((data.devicePaint - oldOpaque).intersects(m_currentBlur)) {
-        data.devicePaint += m_currentBlur;
-    }
-
-    // in case this window has regions to be blurred
-    const Region blurArea = Rect(blurRegion(w).boundingRect().translated(w->pos().toPoint()));
-
-    // if this window or a window underneath the blurred area is painted again we have to
-    // blur everything
-    if (m_paintedArea.intersects(blurArea) || data.devicePaint.intersects(blurArea)) {
-        data.devicePaint += blurArea;
-        // we have to check again whether we do not damage a blurred area
-        // of a window
-        if (blurArea.intersects(m_currentBlur)) {
-            data.devicePaint += m_currentBlur;
-        }
-    }
-
-    m_currentBlur += blurArea;
-
-    m_paintedArea -= data.deviceOpaque;
-    m_paintedArea += data.devicePaint;
+    effects->prePaintScreen(data);
 }
 
 bool BlurEffect::shouldBlur(const EffectWindow *w, int mask, const WindowPaintData &data) const

--- a/src/blur/blur.h
+++ b/src/blur/blur.h
@@ -19,8 +19,6 @@
 namespace KWin
 {
 
-class BlurManagerInterface;
-
 struct BlurRenderData
 {
     /// Temporary render targets needed for the Dual Kawase algorithm, the first texture
@@ -53,8 +51,7 @@ public:
     static bool enabledByDefault();
 
     void reconfigure(ReconfigureFlags flags) override;
-    void prePaintScreen(ScreenPrePaintData &data, std::chrono::milliseconds presentTime) override;
-    void prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds presentTime) override;
+    void prePaintScreen(ScreenPrePaintData &data) override;
     void drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow *w, int mask, const Region &region, WindowPaintData &data) override;
 
     bool provides(Feature feature) override;
@@ -121,8 +118,6 @@ private:
 
     bool m_valid = false;
     long net_wm_blur_region = 0;
-    Region m_paintedArea; // keeps track of all painted areas (from bottom to top)
-    Region m_currentBlur; // keeps track of the currently blured area of the windows(from bottom to top)
     LogicalOutput *m_currentScreen = nullptr;
 
     size_t m_iterationCount; // number of times the texture will be downsized to half size
@@ -149,9 +144,6 @@ private:
 
     QMap<EffectWindow *, QMetaObject::Connection> windowBlurChangedConnections;
     std::unordered_map<EffectWindow *, BlurEffectData> m_windows;
-
-    static BlurManagerInterface *s_blurManager;
-    static QTimer *s_blurManagerRemoveTimer;
 };
 
 inline bool BlurEffect::provides(Effect::Feature feature)

--- a/src/lightlyshaders/lightlyshaders.cpp
+++ b/src/lightlyshaders/lightlyshaders.cpp
@@ -64,7 +64,7 @@ LightlyShadersEffect::LightlyShadersEffect() : OffscreenEffect()
         return;
     }
 
-    if (m_shader->isValid())
+    if (m_shader)
     {
         const auto stackingOrder = effects->stackingOrder();
         for (EffectWindow *window : stackingOrder) {
@@ -219,50 +219,27 @@ LightlyShadersEffect::paintScreen(const RenderTarget &renderTarget, const Render
 }
 
 void
-LightlyShadersEffect::prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data, std::chrono::milliseconds time)
+LightlyShadersEffect::prePaintWindow(RenderView *view, EffectWindow *w, WindowPrePaintData &data)
 {
     if (!isValidWindow(w) )
     {
-        effects->prePaintWindow(view, w, data, time);
+        effects->prePaintWindow(view, w, data);
         return;
     }
 
-    LogicalOutput *s = w->screen();
-    if (effects->waylandDisplay() == nullptr) {
-        s = nullptr;
-    }
+    // The rounded corners cut transparent pixels out of the window, so it can
+    // no longer be treated as fully opaque. Newer KWin no longer exposes the
+    // per-region opaque area on WindowPrePaintData, so mark the whole window
+    // translucent to make KWin blend the corners correctly.
+    data.setTranslucent();
 
-    const QRectF geo(w->frameGeometry());
-    for (int corner = 0; corner < LSHelper::NTex; ++corner)
-    {
-        QRegion reg = QRegion(scale(m_helper->m_maskRegions[corner]->boundingRect(), m_screens[s].scale).toRect());
-        switch(corner) {
-            case LSHelper::TopLeft:
-                reg.translate(geo.x()-m_shadowOffset, geo.y()-m_shadowOffset);
-                break;
-            case LSHelper::TopRight:
-                reg.translate(geo.x() + geo.width() - m_size, geo.y()-m_shadowOffset);
-                break;
-            case LSHelper::BottomRight:
-                reg.translate(geo.x() + geo.width() - m_size-1, geo.y()+geo.height()-m_size-1);
-                break;
-            case LSHelper::BottomLeft:
-                reg.translate(geo.x()-m_shadowOffset+1, geo.y()+geo.height()-m_size-1);
-                break;
-            default:
-                break;
-        }
-
-        data.deviceOpaque -= Region(reg);
-    }
-
-    effects->prePaintWindow(view, w, data, time);
+    effects->prePaintWindow(view, w, data);
 }
 
 bool
 LightlyShadersEffect::isValidWindow(EffectWindow *w)
 {
-    if (!m_shader->isValid()
+    if (!m_shader
             || !m_windows[w].isManaged
             || m_windows[w].skipEffect
         )

--- a/src/lightlyshaders/lightlyshaders.h
+++ b/src/lightlyshaders/lightlyshaders.h
@@ -43,7 +43,7 @@ public:
 
     void reconfigure(ReconfigureFlags flags) override;
     void paintScreen(const RenderTarget &renderTarget, const RenderViewport &viewport, int mask, const Region &region, LogicalOutput *s) override;
-    void prePaintWindow(RenderView *view, EffectWindow* w, WindowPrePaintData& data, std::chrono::milliseconds time) override;
+    void prePaintWindow(RenderView *view, EffectWindow* w, WindowPrePaintData& data) override;
     void drawWindow(const RenderTarget &renderTarget, const RenderViewport &viewport, EffectWindow* w, int mask, const Region& region, WindowPaintData& data) override;
     virtual int requestedEffectChainPosition() const override { return 99; }
 


### PR DESCRIPTION
## Summary

Updates LightlyShaders (and the bundled blur effect) to build and run on
Plasma 6.7 / KWin 6.7, and fixes a crash that took down KWin/plasmashell
when the bundled blur effect was enabled.

## Build fixes (KWin 6.7 effect API changes)

The KWin 6.7 effect API changed in several places. Both effects were
migrated accordingly:

- **`prePaintWindow` / `prePaintScreen`**: dropped the removed
  `std::chrono::milliseconds` time/presentTime parameter.
- **`GLShader::isValid()` removed**: rely on the null check of the shader
  returned by `generateShaderFromFile()` instead.
- **`WindowPrePaintData` opaque/paint regions removed**: use
  `setTranslucent()` to mark the rounded corners for blending; removed the
  blur effect's now-unsupported opaque/paint region bookkeeping
  (`prePaintWindow` dropped entirely, matching upstream KWin).
- **`BlurManagerInterface` (`wayland/blur.h`) no longer exported**: KWin
  core registers the blur Wayland protocol itself, so the effect no longer
  creates it.
- **`SurfaceInterface::blur()->region()` → `blurRegion()`** (returns `RegionF`).
- **`EffectWindow::readProperty()` removed**: read the X11
  `_KDE_NET_WM_BLUR_BEHIND_REGION` property via `Xcb::Property`.
- Restored the local `scaledRect()` helper and converted the now
  `EffectWindow::rect()` explicitly to `QRect`.
- Linked the blur module against `XCB::XCB` for the `Xcb::Proper

## Crash fix

`BlurEffect::blurRegion()` unconditionally dereferenced `w->deco
for windows with a non-empty blur region. Windows without a server-side
decoration (Wayland/CSD windows, plasmashell panels) return a nu
decoration, so enabling **Window background blur (LightlyShaders
KWin — and with it plasmashell — via a null-pointer dereference
`KDecoration3::Decoration::rect()`. It now falls back to the who
rect (`w->rect()`), matching upstream KWin's blur effect.

## Testing

Tested on Arch Linux, Plasma 6.7 / KWin 6.7.1 (Wayland):

- Clean build of all targets succeeds.
- The LightlyShaders effect loads (`isEffectLoaded` = true) and
  corners render correctly on windows.
- Enabling the bundled blur effect no longer crashes KWin/plasmashell;
  blur renders on panels and CSD windows.

## Docs

- README / README_zh updated to state Plasma >= 6.7.